### PR TITLE
Added LocalStorage, Creating Initial Cart on Load

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,4 +47,5 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: ['node_modules/', '.cache/', 'public/'],
 };

--- a/config/__mocks__/browser-mocks.js
+++ b/config/__mocks__/browser-mocks.js
@@ -1,0 +1,25 @@
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key] || null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = value;
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+
+Object.defineProperty(window, 'localStorage', {
+  value: new LocalStorageMock(),
+});

--- a/config/__mocks__/shopify-buy.js
+++ b/config/__mocks__/shopify-buy.js
@@ -1,5 +1,5 @@
 const shopifyBuy = jest.requireActual('shopify-buy');
-const TestHelpers = require('../../gatsby-theme-shopify-core/src/utils/TestHelpers');
+const MocksFolder = require('../../gatsby-theme-shopify-core/src/mocks');
 
 shopifyBuy.buildClient = ({storefrontAccessToken, domain}) => {
   if (storefrontAccessToken == null) {
@@ -10,7 +10,7 @@ shopifyBuy.buildClient = ({storefrontAccessToken, domain}) => {
     throw new Error('new Config() requires the option domain');
   }
 
-  return TestHelpers.MOCK_CLIENT;
+  return MocksFolder.Mocks.CLIENT;
 };
 
 export default shopifyBuy;

--- a/gatsby-theme-shopify-core/src/ContextProvider.tsx
+++ b/gatsby-theme-shopify-core/src/ContextProvider.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import ShopifyBuy from 'shopify-buy';
 import {Context} from './Context';
+import {LocalStorage, LocalStorageKeys} from './utils';
 
 interface Props {
   shopName: string;
@@ -22,20 +23,14 @@ export function ContextProvider({shopName, accessToken, children}: Props) {
   });
 
   useEffect(() => {
-    let mounted = true;
-
     async function setupCart() {
-      if (mounted) {
-        const cart = await client.checkout.create();
-        setCart(cart);
-      }
+      const newCart = await client.checkout.create();
+
+      setCart(newCart);
+      LocalStorage.set(JSON.stringify(newCart), LocalStorageKeys.CART);
     }
 
     setupCart();
-
-    return () => {
-      mounted = false;
-    };
   }, []);
 
   return (

--- a/gatsby-theme-shopify-core/src/__tests__/ContextProvider.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/ContextProvider.test.tsx
@@ -2,8 +2,14 @@ import React, {useContext} from 'react';
 import {render, wait} from '@testing-library/react';
 import {Context} from '../Context';
 import {ContextProvider} from '../ContextProvider';
-import {TestHelpers} from '../utils';
+import {Mocks} from '../mocks';
+import {LocalStorage, LocalStorageKeys} from '../utils';
 import ShopifyBuy from 'shopify-buy';
+
+function MockComponent() {
+  const {cart} = useContext(Context);
+  return <p>{cart?.id}</p>;
+}
 
 describe('ContextProvider', () => {
   it('throws an error if the accessToken is missing', () => {
@@ -21,7 +27,7 @@ describe('ContextProvider', () => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
           accessToken={null}
-          shopName={TestHelpers.MOCK_SHOP_NAME}
+          shopName={Mocks.SHOP_NAME}
         >
           <MockComponent />
         </ContextProvider>,
@@ -32,11 +38,6 @@ describe('ContextProvider', () => {
   });
 
   it('throws an error if the shopName is missing', () => {
-    function MockComponent() {
-      const {client} = useContext(Context);
-      return <p>{typeof client}</p>;
-    }
-
     const originalError = console.error;
     console.error = jest.fn();
 
@@ -46,7 +47,7 @@ describe('ContextProvider', () => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
           shopName={null}
-          accessToken={TestHelpers.MOCK_ACCESS_TOKEN}
+          accessToken={Mocks.ACCESS_TOKEN}
         >
           <MockComponent />
         </ContextProvider>,
@@ -58,15 +59,11 @@ describe('ContextProvider', () => {
 
   it('passes the shopName and accessToken to the shopify-buy client', async () => {
     const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
-    function MockComponent() {
-      const {client} = useContext(Context);
-      return <p>{typeof client}</p>;
-    }
 
     render(
       <ContextProvider
-        shopName={TestHelpers.MOCK_SHOP_NAME}
-        accessToken={TestHelpers.MOCK_ACCESS_TOKEN}
+        shopName={Mocks.SHOP_NAME}
+        accessToken={Mocks.ACCESS_TOKEN}
       >
         <MockComponent />
       </ContextProvider>,
@@ -74,24 +71,17 @@ describe('ContextProvider', () => {
 
     await wait(() =>
       expect(shopifyBuySpy).toHaveBeenCalledWith({
-        storefrontAccessToken: TestHelpers.MOCK_ACCESS_TOKEN,
-        domain: TestHelpers.MOCK_DOMAIN,
+        storefrontAccessToken: Mocks.ACCESS_TOKEN,
+        domain: Mocks.DOMAIN,
       }),
     );
   });
 
   it('builds a shopify-buy client', async () => {
     const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
-    function MockComponent() {
-      const {client} = useContext(Context);
-      return <p>{typeof client}</p>;
-    }
 
     render(
-      <ContextProvider
-        shopName={TestHelpers.MOCK_DOMAIN}
-        accessToken={TestHelpers.MOCK_ACCESS_TOKEN}
-      >
+      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
         <MockComponent />
       </ContextProvider>,
     );
@@ -112,8 +102,8 @@ describe('ContextProvider', () => {
 
     const wrapper = render(
       <ContextProvider
-        shopName={TestHelpers.MOCK_SHOP_NAME}
-        accessToken={TestHelpers.MOCK_ACCESS_TOKEN}
+        shopName={Mocks.SHOP_NAME}
+        accessToken={Mocks.ACCESS_TOKEN}
       >
         <MockComponent />
       </ContextProvider>,
@@ -137,13 +127,50 @@ describe('ContextProvider', () => {
 
     const wrapper = render(
       <ContextProvider
-        shopName={TestHelpers.MOCK_SHOP_NAME}
-        accessToken={TestHelpers.MOCK_ACCESS_TOKEN}
+        shopName={Mocks.SHOP_NAME}
+        accessToken={Mocks.ACCESS_TOKEN}
       >
         <MockComponent />
       </ContextProvider>,
     );
 
     expect(wrapper.findByText('pass')).toBeTruthy();
+  });
+
+  it('creates a new cart object', async () => {
+    const createCartSpy = jest.spyOn(Mocks.CLIENT.checkout, 'create');
+
+    function MockComponent() {
+      const {cart} = useContext(Context);
+      const content = cart?.id === Mocks.CART.id ? 'pass' : 'fail';
+
+      return <p>{content}</p>;
+    }
+
+    const wrapper = render(
+      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+        <MockComponent />
+      </ContextProvider>,
+    );
+
+    await wait(() => {
+      expect(createCartSpy).toHaveBeenCalled();
+      expect(wrapper.getByText('pass')).toBeTruthy();
+    });
+  });
+
+  it('saves the new cart object in local storage', async () => {
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+
+    render(
+      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+        <MockComponent />
+      </ContextProvider>,
+    );
+
+    await wait(() => {
+      expect(localStorageSpy).toHaveBeenCalled();
+      expect(window.localStorage.getItem(LocalStorageKeys.CART)).not.toBeNull();
+    });
   });
 });

--- a/gatsby-theme-shopify-core/src/mocks/cart.ts
+++ b/gatsby-theme-shopify-core/src/mocks/cart.ts
@@ -1,4 +1,4 @@
-export const MOCK_CART = {
+export const CART = {
   id:
     'Z2lkOi8vc2hvcGlmeS9DaGVja291dC81ZWQ3MzhhOTYwYzYyM2E2YzUzZWRmZDE3NDAxNzE0Mz9rZXk9OGQyZTc2OTkyNzc1NjE0ZGM0ODFiNzQyMTY1YWFkNzM=',
   ready: true,

--- a/gatsby-theme-shopify-core/src/mocks/client.ts
+++ b/gatsby-theme-shopify-core/src/mocks/client.ts
@@ -1,10 +1,10 @@
-import {MOCK_CART} from './mockCart';
+import {CART} from './cart';
 
-export const MOCK_CLIENT = {
+export const CLIENT = {
   product: {},
   collection: {},
   checkout: {
-    create: jest.fn(() => MOCK_CART),
+    create: jest.fn(() => CART),
     fetch: jest.fn(),
     addLineItems: jest.fn(),
     clearLineItems: jest.fn(),

--- a/gatsby-theme-shopify-core/src/mocks/constants.ts
+++ b/gatsby-theme-shopify-core/src/mocks/constants.ts
@@ -1,0 +1,3 @@
+export const ACCESS_TOKEN = 'access123';
+export const SHOP_NAME = 'some-shop';
+export const DOMAIN = `${SHOP_NAME}.myshopify.com`;

--- a/gatsby-theme-shopify-core/src/mocks/index.ts
+++ b/gatsby-theme-shopify-core/src/mocks/index.ts
@@ -1,0 +1,13 @@
+import {CART} from './cart';
+import {CLIENT} from './client';
+import {ACCESS_TOKEN, SHOP_NAME, DOMAIN} from './constants';
+
+const Mocks = {
+  CART,
+  CLIENT,
+  ACCESS_TOKEN,
+  SHOP_NAME,
+  DOMAIN,
+};
+
+export {Mocks};

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/LocalStorage.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/LocalStorage.ts
@@ -1,0 +1,20 @@
+export function set(value: string, key: string) {
+  const isBrowser = typeof window !== 'undefined';
+  if (isBrowser) {
+    window.localStorage.setItem(key, value);
+  }
+}
+
+export function get(key: string) {
+  const isBrowser = typeof window !== 'undefined';
+  if (!isBrowser) {
+    return null;
+  }
+
+  try {
+    const item = window.localStorage.getItem(key);
+    return item;
+  } catch {
+    return null;
+  }
+}

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/__tests__/LocalStorage.test.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/__tests__/LocalStorage.test.ts
@@ -1,0 +1,37 @@
+import {LocalStorage} from '../../LocalStorage';
+
+describe('LocalStorage.set()', () => {
+  it('sets a key in localStorage', () => {
+    const key = 'checkoutId';
+    const value = 'checkout_1';
+
+    const setItemSpy = jest.spyOn(window.localStorage, 'setItem');
+    LocalStorage.set(value, key);
+
+    expect(setItemSpy).toHaveBeenCalledWith(key, value);
+  });
+});
+
+describe('LocalStorage.get()', () => {
+  it('gets a value from localStorage', () => {
+    const key = 'checkoutId';
+    const value = 'checkout_1';
+    LocalStorage.set(value, key);
+
+    const getItemSpy = jest.spyOn(window.localStorage, 'getItem');
+    const newValue = LocalStorage.get(key);
+
+    expect(newValue).toBe(value);
+    expect(getItemSpy).toHaveBeenCalledWith(key);
+  });
+
+  it('returns null when there is no value in localStorage', () => {
+    const key = 'unknown_key';
+
+    const getItemSpy = jest.spyOn(window.localStorage, 'getItem');
+    const newValue = LocalStorage.get(key);
+
+    expect(newValue).toBeNull();
+    expect(getItemSpy).toHaveBeenCalledWith(key);
+  });
+});

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/index.ts
@@ -1,0 +1,3 @@
+import * as LocalStorage from './LocalStorage';
+import * as LocalStorageKeys from './keys';
+export {LocalStorage, LocalStorageKeys};

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/keys.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/keys.ts
@@ -1,0 +1,2 @@
+export const CART = 'shopify_local_store__cart';
+export const CHECKOUT_ID = 'shopify_local_store__checkout_id';

--- a/gatsby-theme-shopify-core/src/utils/TestHelpers/constants.ts
+++ b/gatsby-theme-shopify-core/src/utils/TestHelpers/constants.ts
@@ -1,3 +1,0 @@
-export const MOCK_ACCESS_TOKEN = 'access123';
-export const MOCK_SHOP_NAME = 'some-shop';
-export const MOCK_DOMAIN = `${MOCK_SHOP_NAME}.myshopify.com`;

--- a/gatsby-theme-shopify-core/src/utils/TestHelpers/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/TestHelpers/index.ts
@@ -1,3 +1,0 @@
-export * from './constants';
-export {MOCK_CART} from './mockCart';
-export {MOCK_CLIENT} from './mockClient';

--- a/gatsby-theme-shopify-core/src/utils/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/index.ts
@@ -1,3 +1,4 @@
 import {useCoreOptions} from './useCoreOptions';
-import * as TestHelpers from './TestHelpers';
-export {TestHelpers, useCoreOptions};
+import {LocalStorage, LocalStorageKeys} from './LocalStorage';
+
+export {useCoreOptions, LocalStorage, LocalStorageKeys};

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,10 @@ module.exports = {
     __PATH_PREFIX__: ``,
   },
   testURL: `http://localhost`,
-  setupFiles: [`<rootDir>/config/loadershim.js`],
+  setupFiles: [
+    `<rootDir>/config/loadershim.js`,
+    `<rootDir>/config/__mocks__/browser-mocks.js`,
+  ],
   setupFilesAfterEnv: ['<rootDir>/config/setup-test-env.js'],
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(jsx?|tsx?)$',
 };


### PR DESCRIPTION
This PR:
- Adds LocalStorage helpers
- Creates the Cart object in a `useEffect` within the provider
- Refactors the mocks so they don't break consumers of the theme (`TestHelpers` -> `Mocks`)