### PR TITLE
Loading Initial Cart State from Local Storage

### DIFF
--- a/gatsby-theme-shopify-core/src/Context.tsx
+++ b/gatsby-theme-shopify-core/src/Context.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import ShopifyBuy from 'shopify-buy';
 
 interface ContextShape {
-  client?: ShopifyBuy.Client;
-  cart?: ShopifyBuy.Cart;
-  setCart: React.Dispatch<React.SetStateAction<ShopifyBuy.Cart | undefined>>;
+  client: ShopifyBuy.Client | null;
+  cart: ShopifyBuy.Cart | null;
+  setCart: React.Dispatch<React.SetStateAction<ShopifyBuy.Cart | null>>;
 }
 
 export const Context = React.createContext<ContextShape>({
-  client: undefined,
-  cart: undefined,
+  client: null,
+  cart: null,
   setCart: () => {
     throw Error('You forgot to wrap this in a Provider object');
   },

--- a/gatsby-theme-shopify-core/src/ContextProvider.tsx
+++ b/gatsby-theme-shopify-core/src/ContextProvider.tsx
@@ -16,21 +16,24 @@ export function ContextProvider({shopName, accessToken, children}: Props) {
     );
   }
 
-  const [cart, setCart] = useState<ShopifyBuy.Cart>();
+  const initialCart = LocalStorage.getInitialCart();
+  const [cart, setCart] = useState<ShopifyBuy.Cart | null>(initialCart);
   const client = ShopifyBuy.buildClient({
     storefrontAccessToken: accessToken,
     domain: `${shopName}.myshopify.com`,
   });
 
   useEffect(() => {
-    async function setupCart() {
+    async function getNewCart() {
       const newCart = await client.checkout.create();
 
       setCart(newCart);
-      LocalStorage.set(JSON.stringify(newCart), LocalStorageKeys.CART);
+      LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(newCart));
     }
 
-    setupCart();
+    if (cart == null) {
+      getNewCart();
+    }
   }, []);
 
   return (

--- a/gatsby-theme-shopify-core/src/__tests__/Context.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/Context.test.tsx
@@ -3,10 +3,10 @@ import {render} from '@testing-library/react';
 import {Context} from '../Context';
 
 describe('Context', () => {
-  it('returns undefined as the default value for the client', () => {
+  it('returns null as the default value for the client', () => {
     function MockComponent() {
       const {client} = useContext(Context);
-      const content = client === undefined ? 'pass' : 'fail';
+      const content = client === null ? 'pass' : 'fail';
 
       return <p>{content}</p>;
     }
@@ -15,10 +15,10 @@ describe('Context', () => {
     expect(getAllByText('pass')).toBeTruthy();
   });
 
-  it('returns undefined as the default value for the cart', () => {
+  it('returns null as the default value for the cart', () => {
     function MockComponent() {
       const {cart} = useContext(Context);
-      const content = cart === undefined ? 'pass' : 'fail';
+      const content = cart === null ? 'pass' : 'fail';
 
       return <p>{content}</p>;
     }
@@ -32,7 +32,7 @@ describe('Context', () => {
       const {setCart} = useContext(Context);
 
       try {
-        setCart(undefined);
+        setCart(null);
       } catch (error) {
         return <p>{error.message}</p>;
       }

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/LocalStorage.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/LocalStorage.ts
@@ -1,11 +1,15 @@
-export function set(value: string, key: string) {
+import ShopifyBuy from 'shopify-buy';
+import {LocalStorageKeys} from './keys';
+import {isCart} from '../../utils';
+
+function set(key: string, value: string) {
   const isBrowser = typeof window !== 'undefined';
   if (isBrowser) {
     window.localStorage.setItem(key, value);
   }
 }
 
-export function get(key: string) {
+function get(key: string) {
   const isBrowser = typeof window !== 'undefined';
   if (!isBrowser) {
     return null;
@@ -18,3 +22,27 @@ export function get(key: string) {
     return null;
   }
 }
+
+function getInitialCart(): ShopifyBuy.Cart | null {
+  const existingCartString = get(LocalStorageKeys.CART);
+  if (existingCartString == null) {
+    return null;
+  }
+
+  try {
+    const existingCart = JSON.parse(existingCartString);
+    if (!isCart(existingCart)) {
+      return null;
+    }
+
+    return existingCart as ShopifyBuy.Cart;
+  } catch {
+    return null;
+  }
+}
+
+export const LocalStorage = {
+  get,
+  set,
+  getInitialCart,
+};

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/__tests__/LocalStorage.test.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/__tests__/LocalStorage.test.ts
@@ -1,4 +1,6 @@
 import {LocalStorage} from '../../LocalStorage';
+import {Mocks} from '../../../mocks';
+import {LocalStorageKeys} from '../keys';
 
 describe('LocalStorage.set()', () => {
   it('sets a key in localStorage', () => {
@@ -6,7 +8,7 @@ describe('LocalStorage.set()', () => {
     const value = 'checkout_1';
 
     const setItemSpy = jest.spyOn(window.localStorage, 'setItem');
-    LocalStorage.set(value, key);
+    LocalStorage.set(key, value);
 
     expect(setItemSpy).toHaveBeenCalledWith(key, value);
   });
@@ -16,7 +18,7 @@ describe('LocalStorage.get()', () => {
   it('gets a value from localStorage', () => {
     const key = 'checkoutId';
     const value = 'checkout_1';
-    LocalStorage.set(value, key);
+    LocalStorage.set(key, value);
 
     const getItemSpy = jest.spyOn(window.localStorage, 'getItem');
     const newValue = LocalStorage.get(key);
@@ -33,5 +35,29 @@ describe('LocalStorage.get()', () => {
 
     expect(newValue).toBeNull();
     expect(getItemSpy).toHaveBeenCalledWith(key);
+  });
+});
+
+describe('LocalStorage.getInitialCart()', () => {
+  it('returns a cart object if it exists', () => {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
+    expect(LocalStorage.getInitialCart()).toEqual(Mocks.CART);
+  });
+
+  it('returns null if there is no stored object', () => {
+    LocalStorage.set(LocalStorageKeys.CART, '');
+    expect(LocalStorage.getInitialCart()).toBeNull();
+  });
+
+  it('returns null if the stored object is invalid JSON', () => {
+    LocalStorage.set(LocalStorageKeys.CART, "{id: 'asdf', lineItems: []");
+    expect(LocalStorage.getInitialCart()).toBeNull();
+  });
+
+  it('returns null if the stored object is not a valid cart', () => {
+    const badCart = {...Mocks.CART, type: {}};
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(badCart));
+
+    expect(LocalStorage.getInitialCart()).toBeNull();
   });
 });

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/index.ts
@@ -1,3 +1,4 @@
-import * as LocalStorage from './LocalStorage';
-import * as LocalStorageKeys from './keys';
+import {LocalStorage} from './LocalStorage';
+import {LocalStorageKeys} from './keys';
+
 export {LocalStorage, LocalStorageKeys};

--- a/gatsby-theme-shopify-core/src/utils/LocalStorage/keys.ts
+++ b/gatsby-theme-shopify-core/src/utils/LocalStorage/keys.ts
@@ -1,2 +1,7 @@
-export const CART = 'shopify_local_store__cart';
-export const CHECKOUT_ID = 'shopify_local_store__checkout_id';
+const CART = 'shopify_local_store__cart';
+const CHECKOUT_ID = 'shopify_local_store__checkout_id';
+
+export const LocalStorageKeys = {
+  CART,
+  CHECKOUT_ID,
+};

--- a/gatsby-theme-shopify-core/src/utils/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/index.ts
@@ -1,4 +1,5 @@
 import {useCoreOptions} from './useCoreOptions';
 import {LocalStorage, LocalStorageKeys} from './LocalStorage';
+import {isCart} from './types';
 
-export {useCoreOptions, LocalStorage, LocalStorageKeys};
+export {useCoreOptions, LocalStorage, LocalStorageKeys, isCart};

--- a/gatsby-theme-shopify-core/src/utils/types/__tests__/isCart.test.ts
+++ b/gatsby-theme-shopify-core/src/utils/types/__tests__/isCart.test.ts
@@ -1,0 +1,20 @@
+import {isCart} from '../isCart';
+import {Mocks} from '../../../mocks';
+
+describe('isCart()', () => {
+  it('returns true for an input that is a valid Cart', () => {
+    expect(isCart(Mocks.CART)).toBe(true);
+  });
+
+  it('returns false for an input that is not a valid Cart', () => {
+    const badCart = {
+      id: 'some id',
+      lineItems: null,
+    };
+
+    expect(isCart(badCart)).toBe(false);
+    expect(isCart('')).toBe(false);
+    expect(isCart({})).toBe(false);
+    expect(isCart(null)).toBe(false);
+  });
+});

--- a/gatsby-theme-shopify-core/src/utils/types/index.ts
+++ b/gatsby-theme-shopify-core/src/utils/types/index.ts
@@ -1,0 +1,1 @@
+export {isCart} from './isCart';

--- a/gatsby-theme-shopify-core/src/utils/types/isCart.ts
+++ b/gatsby-theme-shopify-core/src/utils/types/isCart.ts
@@ -1,0 +1,14 @@
+import ShopifyBuy from 'shopify-buy';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isCart(potentialCart: any): potentialCart is ShopifyBuy.Cart {
+  return (
+    potentialCart != null &&
+    potentialCart.id != null &&
+    potentialCart.webUrl != null &&
+    potentialCart.lineItems != null &&
+    potentialCart.type != null &&
+    potentialCart.type.name === 'Checkout' &&
+    potentialCart.type.kind === 'OBJECT'
+  );
+}


### PR DESCRIPTION
This PR:
- Loads the initial cart state from local storage in the provider
- Adds a typeguard for the shopify `Cart` type called `isCart`
- Adds a `getInitialCart` function to `LocalStorage`
- General tweaks associated with these changes