### PR TITLE
Add useAddItemsToCart

### DIFF
--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 import Image from 'gatsby-image';
-import {useClient, useCart, useCartCount} from 'gatsby-theme-shopify-core';
+import {
+  useClient,
+  useCart,
+  useCartCount,
+  useAddItemsToCart,
+} from 'gatsby-theme-shopify-core';
 
 function IndexPage({data}) {
   const {
@@ -14,19 +19,17 @@ function IndexPage({data}) {
   });
 
   const client = useClient();
-  const {cart, setCart} = useCart();
+  const {setCart} = useCart();
   const cartCount = useCartCount();
+  const addItemsToCart = useAddItemsToCart();
 
   async function addToCart(shopifyId) {
-    const newCart = await client.checkout.addLineItems(cart.id, [
-      {
-        variantId: shopifyId,
-        quantity: 1,
-      },
-    ]);
-
-    console.log(newCart);
-    setCart(newCart);
+    const result = await addItemsToCart([{variantId: shopifyId, quantity: 1}]);
+    const message =
+      result === true
+        ? 'Successfully added to cart!'
+        : 'There was a problem adding this to the cart.';
+    alert(message);
   }
 
   async function clearCart() {

--- a/gatsby-theme-shopify-core/src/__tests__/.eslintrc
+++ b/gatsby-theme-shopify-core/src/__tests__/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/ban-ts-ignore": "off"
+  }
+}

--- a/gatsby-theme-shopify-core/src/__tests__/ContextProvider.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/ContextProvider.test.tsx
@@ -29,7 +29,6 @@ describe('ContextProvider', () => {
     expect(() =>
       render(
         <ContextProvider
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
           accessToken={null}
           shopName={Mocks.SHOP_NAME}
@@ -49,7 +48,6 @@ describe('ContextProvider', () => {
     expect(() =>
       render(
         <ContextProvider
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
           shopName={null}
           accessToken={Mocks.ACCESS_TOKEN}

--- a/gatsby-theme-shopify-core/src/__tests__/useAddItemsToCart.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/useAddItemsToCart.test.tsx
@@ -1,0 +1,110 @@
+import React, {useState} from 'react';
+import {wait, fireEvent} from '@testing-library/react';
+import {renderWithContext} from '../mocks';
+import {LocalStorage, LocalStorageKeys} from '../utils';
+import {useAddItemsToCart} from '../useAddItemsToCart';
+import {LineItemPatch} from '../types';
+
+function MockComponent({items}: {items: LineItemPatch[]}) {
+  const addItemsToCart = useAddItemsToCart();
+  const [result, setResult] = useState<boolean | null>(null);
+
+  async function addItem() {
+    const newResult = await addItemsToCart(items);
+    setResult(newResult);
+  }
+
+  return (
+    <>
+      <button type="button" onClick={addItem}>
+        Add to Cart
+      </button>
+      <p>Result: {String(result)}</p>
+    </>
+  );
+}
+
+const originalError = console.error;
+const mockConsoleError = jest.fn();
+
+beforeEach(() => {
+  console.error = mockConsoleError;
+});
+
+afterEach(() => {
+  LocalStorage.set(LocalStorageKeys.CART, '');
+  jest.clearAllMocks();
+  console.error = originalError;
+});
+
+describe('useAddItemsToCart()', () => {
+  it('returns true if the items are added to the cart', async () => {
+    const wrapper = renderWithContext(
+      <MockComponent
+        items={[
+          {
+            variantId: 'variantId',
+            quantity: 1,
+          },
+        ]}
+      />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: true/)).toBeTruthy();
+  });
+
+  it('updates the cart state if the items are added to the cart', async () => {
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+    const wrapper = renderWithContext(
+      <MockComponent
+        items={[
+          {
+            variantId: 'newVariantId',
+            quantity: 1,
+          },
+        ]}
+      />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    const newCart = JSON.parse(
+      LocalStorage.get(LocalStorageKeys.CART) || '',
+    ) as ShopifyBuy.Cart;
+
+    // @ts-ignore
+    expect(newCart.lineItems.slice(-1)[0].variantId).toBe('newVariantId');
+    expect(localStorageSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false if there are no items passed to the function', async () => {
+    const wrapper = renderWithContext(<MockComponent items={[]} />);
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Must include at least one line item, empty line items found',
+    );
+  });
+
+  it("returns false if the input does not conform to the client's protocol", async () => {
+    const items = [{variantId: 'variantId'}];
+    const wrapper = renderWithContext(
+      <MockComponent
+        // @ts-ignore
+        items={items}
+      />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+  });
+});

--- a/gatsby-theme-shopify-core/src/__tests__/useCartCount.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/useCartCount.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {render, wait} from '@testing-library/react';
-import {ContextProvider} from '../ContextProvider';
-import {Mocks} from '../mocks';
+import {wait} from '@testing-library/react';
+import {Mocks, renderWithContext} from '../mocks';
 import {LocalStorage, LocalStorageKeys} from '../utils';
 import {useCartCount} from '../useCartCount';
 
@@ -17,13 +16,7 @@ afterEach(() => {
 
 describe('useCartCount()', () => {
   it('returns the total number of items in the cart, factoring in quantity per variant', async () => {
-    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
-
-    const wrapper = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
-        <MockComponent />
-      </ContextProvider>,
-    );
+    const wrapper = renderWithContext(<MockComponent />);
 
     await wait(() => {
       expect(Mocks.CART.lineItems).toHaveLength(2);
@@ -33,12 +26,9 @@ describe('useCartCount()', () => {
 
   it('returns 0 if the cart is null or empty', async () => {
     LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.EMPTY_CART));
-
-    const wrapper = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
-        <MockComponent />
-      </ContextProvider>,
-    );
+    const wrapper = renderWithContext(<MockComponent />, {
+      shouldSetInitialCart: false,
+    });
 
     await wait(() => {
       expect(wrapper.getByText('0')).toBeTruthy();

--- a/gatsby-theme-shopify-core/src/index.ts
+++ b/gatsby-theme-shopify-core/src/index.ts
@@ -2,3 +2,4 @@ export {ContextProvider} from './ContextProvider';
 export {useClient} from './useClient';
 export {useCart} from './useCart';
 export {useCartCount} from './useCartCount';
+export {useAddItemsToCart} from './useAddItemsToCart';

--- a/gatsby-theme-shopify-core/src/mocks/client.ts
+++ b/gatsby-theme-shopify-core/src/mocks/client.ts
@@ -6,7 +6,36 @@ export const CLIENT = {
   checkout: {
     create: jest.fn(() => CART),
     fetch: jest.fn(),
-    addLineItems: jest.fn(),
+    addLineItems: jest.fn((cartId, items) => {
+      if (items.length < 1) {
+        throw new Error(
+          'Must include at least one line item, empty line items found',
+        );
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      items.forEach((item: any) => {
+        if (item.variantId == null) {
+          throw new Error(`Missing variantId in item`);
+        }
+
+        if (item.quantity == null) {
+          throw new Error(
+            `Missing quantity in item with variant id ${item.variantId}`,
+          );
+        } else if (typeof item.quantity != 'number') {
+          throw new Error(
+            `Quantity is not a number in item with variant id ${item.variantId}`,
+          );
+        } else if (item.quantity < 1) {
+          throw new Error(
+            `Quantity must not be less than one in item with variant id ${item.variantId}`,
+          );
+        }
+      });
+
+      return {...CART, lineItems: [...CART.lineItems, ...items]};
+    }),
     clearLineItems: jest.fn(),
     addVariants: jest.fn(),
     removeLineItems: jest.fn(),

--- a/gatsby-theme-shopify-core/src/mocks/index.ts
+++ b/gatsby-theme-shopify-core/src/mocks/index.ts
@@ -2,6 +2,7 @@ import {CART} from './cart';
 import {EMPTY_CART} from './emptyCart';
 import {CLIENT} from './client';
 import {ACCESS_TOKEN, SHOP_NAME, DOMAIN} from './constants';
+import {renderWithContext} from './renderWithContext';
 
 const Mocks = {
   CART,
@@ -12,4 +13,4 @@ const Mocks = {
   DOMAIN,
 };
 
-export {Mocks};
+export {Mocks, renderWithContext};

--- a/gatsby-theme-shopify-core/src/mocks/renderWithContext.tsx
+++ b/gatsby-theme-shopify-core/src/mocks/renderWithContext.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import {ContextProvider} from '../ContextProvider';
+import {DOMAIN, ACCESS_TOKEN} from './constants';
+import {CART} from './cart';
+import {LocalStorage, LocalStorageKeys} from '../utils';
+
+interface Options {
+  shopName: string;
+  accessToken: string;
+  shouldSetInitialCart: boolean;
+}
+
+export function renderWithContext(
+  component: JSX.Element,
+  givenOptions?: Partial<Options>,
+) {
+  const defaults = {
+    shopName: DOMAIN,
+    accessToken: ACCESS_TOKEN,
+    shouldSetInitialCart: true,
+  };
+
+  const options = Object.assign({}, defaults, givenOptions);
+
+  if (options.shouldSetInitialCart) {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(CART));
+  }
+
+  return render(
+    <ContextProvider
+      shopName={options.shopName}
+      accessToken={options.accessToken}
+    >
+      {component}
+    </ContextProvider>,
+  );
+}

--- a/gatsby-theme-shopify-core/src/types.ts
+++ b/gatsby-theme-shopify-core/src/types.ts
@@ -1,0 +1,9 @@
+export interface AttributeInput {
+  [key: string]: string;
+}
+
+export interface LineItemPatch {
+  variantId: string | number;
+  quantity: number;
+  customAttributes?: AttributeInput[];
+}

--- a/gatsby-theme-shopify-core/src/useAddItemsToCart.tsx
+++ b/gatsby-theme-shopify-core/src/useAddItemsToCart.tsx
@@ -1,0 +1,38 @@
+import {useContext} from 'react';
+import {Context} from './Context';
+import ShopifyBuy from 'shopify-buy';
+import {LineItemPatch} from './types';
+
+export function useAddItemsToCart() {
+  const {client, cart, setCart} = useContext(Context);
+
+  async function addItemsToCart(items: LineItemPatch[]) {
+    if (cart == null || client == null) {
+      console.error('Called addItemsToCart too soon');
+      return false;
+    }
+
+    if (items.length < 1) {
+      console.error(
+        'Must include at least one line item, empty line items found',
+      );
+      return false;
+    }
+
+    try {
+      const newCart = await client.checkout.addLineItems(
+        cart.id,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        items as ShopifyBuy.LineItem[],
+      );
+      setCart(newCart);
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }
+
+  return addItemsToCart;
+}


### PR DESCRIPTION
This PR:
- Adds the` useAddItemsToCart` hook
- Adds a little bit of code to the example site (mostly just as a playground right now)
- Adds `renderWithContext` helper

Note: there are a number of `// @ts-ignore`. Unfortunately the types package (https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/shopify-buy) is out of date. I'm deciding what to do about that, but in the meantime I'm using "patched" types.