### PR TITLE
Add useAddItemToCart

### DIFF
--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {graphql} from 'gatsby';
 import Image from 'gatsby-image';
 import {
   useClient,
   useCart,
   useCartCount,
-  useAddItemsToCart,
+  useAddItemToCart,
 } from 'gatsby-theme-shopify-core';
 
 function IndexPage({data}) {
@@ -18,18 +18,22 @@ function IndexPage({data}) {
     return {...variant, title};
   });
 
+  const [isLoading, setIsLoading] = useState(false);
+
   const client = useClient();
   const {setCart} = useCart();
   const cartCount = useCartCount();
-  const addItemsToCart = useAddItemsToCart();
+  const addItemToCart = useAddItemToCart();
 
   async function addToCart(shopifyId) {
-    const result = await addItemsToCart([{variantId: shopifyId, quantity: 1}]);
+    setIsLoading(true);
+    const result = await addItemToCart(shopifyId, 1);
     const message =
       result === true
         ? 'Successfully added to cart!'
         : 'There was a problem adding this to the cart.';
     alert(message);
+    setIsLoading(false);
   }
 
   async function clearCart() {
@@ -57,8 +61,12 @@ function IndexPage({data}) {
             <div style={{maxWidth: '200px'}}>
               <Image fluid={variant.image.localFile.childImageSharp.fluid} />
             </div>
-            <button type="button" onClick={() => addToCart(variant.shopifyId)}>
-              Add to Cart
+            <button
+              disabled={isLoading}
+              type="button"
+              onClick={() => addToCart(variant.shopifyId)}
+            >
+              {isLoading ? 'Loading...' : 'Add to Cart'}
             </button>
           </div>
         );

--- a/gatsby-theme-shopify-core/src/__tests__/useAddItemToCart.test.tsx
+++ b/gatsby-theme-shopify-core/src/__tests__/useAddItemToCart.test.tsx
@@ -1,0 +1,101 @@
+import React, {useState} from 'react';
+import {wait, fireEvent} from '@testing-library/react';
+import {renderWithContext} from '../mocks';
+import {LocalStorage, LocalStorageKeys} from '../utils';
+import {useAddItemToCart} from '../useAddItemToCart';
+import {AttributeInput} from '../types';
+
+function MockComponent({
+  variantId,
+  quantity,
+  customAttributes,
+}: {
+  variantId: string | number;
+  quantity: number;
+  customAttributes?: AttributeInput[];
+}) {
+  const addItemToCart = useAddItemToCart();
+  const [result, setResult] = useState<boolean | null>(null);
+
+  async function addItem() {
+    const newResult = await addItemToCart(
+      variantId,
+      quantity,
+      customAttributes,
+    );
+    setResult(newResult);
+  }
+
+  return (
+    <>
+      <button type="button" onClick={addItem}>
+        Add to Cart
+      </button>
+      <p>Result: {String(result)}</p>
+    </>
+  );
+}
+
+const originalError = console.error;
+const mockConsoleError = jest.fn();
+
+beforeEach(() => {
+  console.error = mockConsoleError;
+});
+
+afterEach(() => {
+  LocalStorage.set(LocalStorageKeys.CART, '');
+  jest.clearAllMocks();
+  console.error = originalError;
+});
+
+describe('useAddItemToCart()', () => {
+  it('returns true if the item is added to the cart', async () => {
+    const wrapper = renderWithContext(
+      <MockComponent variantId={'some_variant_id'} quantity={1} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: true/)).toBeTruthy();
+  });
+
+  it('updates the cart state if the items are added to the cart', async () => {
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+    const wrapper = renderWithContext(
+      <MockComponent variantId="newVariantId" quantity={1} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    const newCart = JSON.parse(
+      LocalStorage.get(LocalStorageKeys.CART) || '',
+    ) as ShopifyBuy.Cart;
+
+    // @ts-ignore
+    expect(newCart.lineItems.slice(-1)[0].variantId).toBe('newVariantId');
+    expect(localStorageSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false if there is no variantId passed to the function', async () => {
+    // @ts-ignore
+    const wrapper = renderWithContext(<MockComponent quantity={1} />);
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+  });
+
+  it('returns false if there is no quantity passed to the function', async () => {
+    // @ts-ignore
+    const wrapper = renderWithContext(<MockComponent variantId="someId" />);
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Add to Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+  });
+});

--- a/gatsby-theme-shopify-core/src/index.ts
+++ b/gatsby-theme-shopify-core/src/index.ts
@@ -2,4 +2,5 @@ export {ContextProvider} from './ContextProvider';
 export {useClient} from './useClient';
 export {useCart} from './useCart';
 export {useCartCount} from './useCartCount';
+export {useAddItemToCart} from './useAddItemToCart';
 export {useAddItemsToCart} from './useAddItemsToCart';

--- a/gatsby-theme-shopify-core/src/useAddItemToCart.tsx
+++ b/gatsby-theme-shopify-core/src/useAddItemToCart.tsx
@@ -1,0 +1,16 @@
+import {useAddItemsToCart} from './useAddItemsToCart';
+import {AttributeInput} from './types';
+
+export function useAddItemToCart() {
+  const addItemsToCart = useAddItemsToCart();
+
+  return function addItemToCart(
+    variantId: number | string,
+    quantity: number,
+    customAttributes?: AttributeInput[],
+  ) {
+    const item = [{variantId, quantity, customAttributes}];
+
+    return addItemsToCart(item);
+  };
+}


### PR DESCRIPTION
This PR adds `useAddItemToCart`, a singular version of `useAddItemsToCart`. It uses `useAddItemsToCart` under the hood, and exists primarily as a convenience method.