### PR TITLE
Add useRemoveItemFromCart & useRemoveItemsFromCart

### DIFF
--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -9,6 +9,7 @@ import {
   useUpdateItemQuantity,
   useGetLineItem,
   useCheckoutUrl,
+  useRemoveItemFromCart,
 } from 'gatsby-theme-shopify-core';
 
 function IndexPage({data}) {
@@ -28,6 +29,7 @@ function IndexPage({data}) {
   const {setCart} = useCart();
   const cartCount = useCartCount();
   const addItemToCart = useAddItemToCart();
+  const removeItemFromCart = useRemoveItemFromCart();
   const updateItemQuantity = useUpdateItemQuantity();
   const getLineItem = useGetLineItem();
 
@@ -50,16 +52,27 @@ function IndexPage({data}) {
         : 'There was a problem adding this to the cart.';
     alert(message);
     setIsLoading(false);
-    updateItemQuantity(shopifyId);
   }
 
   async function incrementInCart(shopifyId, quantity) {
+    console.log('was thsi called?');
     setIsLoading(true);
     const result = await updateItemQuantity(shopifyId, quantity);
     const message =
       result === true
         ? 'Successfully added one more to cart!'
         : 'There was a problem adding this to the cart.';
+    alert(message);
+    setIsLoading(false);
+  }
+
+  async function removeFromCart(shopifyId) {
+    setIsLoading(true);
+    const result = await removeItemFromCart(shopifyId);
+    const message =
+      result === true
+        ? 'Removed this from your cart'
+        : 'There was a problem removing this from the cart.';
     alert(message);
     setIsLoading(false);
   }
@@ -120,6 +133,13 @@ function IndexPage({data}) {
                   }
                 >
                   +1
+                </button>
+                <button
+                  disabled={isLoading}
+                  type="button"
+                  onClick={() => removeFromCart(variant.shopifyId)}
+                >
+                  Remove
                 </button>
               </>
             ) : null}

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useRemoveItemFromCart.test.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useRemoveItemFromCart.test.tsx
@@ -1,0 +1,114 @@
+import React, {useState} from 'react';
+import {wait, fireEvent} from '@testing-library/react';
+import {Mocks, renderWithContext} from '../../mocks';
+import {LocalStorage, LocalStorageKeys} from '../../utils';
+import {useRemoveItemFromCart} from '../useRemoveItemFromCart';
+
+function MockComponent({variantId}: {variantId: string}) {
+  const removeItemFromCart = useRemoveItemFromCart();
+  const [result, setResult] = useState<boolean | null>(null);
+
+  async function addItem() {
+    const newResult = await removeItemFromCart(variantId);
+    setResult(newResult);
+  }
+
+  return (
+    <>
+      <button type="button" onClick={addItem}>
+        Remove from Cart
+      </button>
+      <p>Result: {String(result)}</p>
+    </>
+  );
+}
+
+const originalError = console.error;
+const mockConsoleError = jest.fn();
+
+beforeEach(() => {
+  console.error = mockConsoleError;
+});
+
+afterEach(() => {
+  LocalStorage.set(LocalStorageKeys.CART, '');
+  jest.clearAllMocks();
+  console.error = originalError;
+});
+
+describe('useRemoveItemFromCart()', () => {
+  it('returns true if the items are removed from the cart', async () => {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
+
+    const wrapper = renderWithContext(
+      <MockComponent variantId={Mocks.VARIANT_ID_IN_CART} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: true/)).toBeTruthy();
+  });
+
+  it('updates the cart state if the items are removed from the cart', async () => {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+
+    const wrapper = renderWithContext(
+      <MockComponent variantId={Mocks.VARIANT_ID_IN_CART} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    const newCart = JSON.parse(
+      LocalStorage.get(LocalStorageKeys.CART) || '',
+    ) as ShopifyBuy.Cart;
+
+    function findInLineItems(variantId: string) {
+      const result = newCart.lineItems
+        .map((lineItem) => {
+          // @ts-ignore
+          if (lineItem.variant.id === variantId) {
+            return lineItem.id;
+          }
+          return null;
+        })
+        .filter(Boolean);
+      return result;
+    }
+
+    expect(findInLineItems(Mocks.VARIANT_ID_IN_CART)).toHaveLength(0);
+    expect(newCart.lineItems).toHaveLength(Mocks.CART.lineItems.length - 1);
+    expect(localStorageSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false if there are no variant Ids passed to the function', async () => {
+    const wrapper = renderWithContext(
+      <MockComponent
+        // @ts-ignore
+        variantId={null}
+      />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      new Error('VariantId must not be blank or null'),
+    );
+  });
+
+  it('returns false if a given variant Id is not found in the cart', async () => {
+    const wrapper = renderWithContext(<MockComponent variantId="bogus_id" />);
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      new Error('Could not find line item in cart with variant id: bogus_id'),
+    );
+  });
+});

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useRemoveItemsFromCart.test.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useRemoveItemsFromCart.test.tsx
@@ -1,0 +1,115 @@
+import React, {useState} from 'react';
+import {wait, fireEvent} from '@testing-library/react';
+import {Mocks, renderWithContext} from '../../mocks';
+import {LocalStorage, LocalStorageKeys} from '../../utils';
+import {useRemoveItemsFromCart} from '../useRemoveItemsFromCart';
+
+function MockComponent({variantIds}: {variantIds: string[]}) {
+  const removeItemsFromCart = useRemoveItemsFromCart();
+  const [result, setResult] = useState<boolean | null>(null);
+
+  async function addItem() {
+    const newResult = await removeItemsFromCart(variantIds);
+    setResult(newResult);
+  }
+
+  return (
+    <>
+      <button type="button" onClick={addItem}>
+        Remove from Cart
+      </button>
+      <p>Result: {String(result)}</p>
+    </>
+  );
+}
+
+const originalError = console.error;
+const mockConsoleError = jest.fn();
+
+beforeEach(() => {
+  console.error = mockConsoleError;
+});
+
+afterEach(() => {
+  LocalStorage.set(LocalStorageKeys.CART, '');
+  jest.clearAllMocks();
+  console.error = originalError;
+});
+
+describe('useRemoveItemsFromCart()', () => {
+  it('returns true if the items are removed from the cart', async () => {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
+
+    const wrapper = renderWithContext(
+      <MockComponent variantIds={[Mocks.VARIANT_ID_IN_CART]} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: true/)).toBeTruthy();
+  });
+
+  it('updates the cart state if the items are removed from the cart', async () => {
+    LocalStorage.set(LocalStorageKeys.CART, JSON.stringify(Mocks.CART));
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+
+    const wrapper = renderWithContext(
+      <MockComponent variantIds={[Mocks.VARIANT_ID_IN_CART]} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    const newCart = JSON.parse(
+      LocalStorage.get(LocalStorageKeys.CART) || '',
+    ) as ShopifyBuy.Cart;
+
+    function findInLineItems(variantId: string) {
+      const result = newCart.lineItems
+        .map((lineItem) => {
+          // @ts-ignore
+          if (lineItem.variant.id === variantId) {
+            return lineItem.id;
+          }
+          return null;
+        })
+        .filter(Boolean);
+      return result;
+    }
+
+    expect(findInLineItems(Mocks.VARIANT_ID_IN_CART)).toHaveLength(0);
+    expect(newCart.lineItems).toHaveLength(Mocks.CART.lineItems.length - 1);
+    expect(localStorageSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false if there are no variant Ids passed to the function', async () => {
+    const wrapper = renderWithContext(<MockComponent variantIds={[]} />);
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      new Error('Must include at least one item to remove'),
+    );
+  });
+
+  it('returns false if a given variant Id is not found in the cart', async () => {
+    const wrapper = renderWithContext(
+      <MockComponent
+        variantIds={[Mocks.VARIANT_ID_IN_CART, 'some_bogus_id']}
+      />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Remove from Cart/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      new Error(
+        'Could not find line item in cart with variant id: some_bogus_id',
+      ),
+    );
+  });
+});

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useUpdateItemQuantity.test.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useUpdateItemQuantity.test.tsx
@@ -89,7 +89,22 @@ describe('useUpdateItemQuantity()', () => {
 
     expect(wrapper.getByText(/Result: false/)).toBeTruthy();
     expect(mockConsoleError).toHaveBeenCalledWith(
-      'Quantity must be greater than 1',
+      'Quantity must be greater than 0',
+    );
+  });
+
+  it('returns false if quantity less than 0 is provided', async () => {
+    const wrapper = renderWithContext(
+      // @ts-ignore
+      <MockComponent variantId={Mocks.VARIANT_ID_IN_CART} quantity={-1} />,
+    );
+    await wait(() => {
+      fireEvent.click(wrapper.getByText(/Update Quantity/));
+    });
+
+    expect(wrapper.getByText(/Result: false/)).toBeTruthy();
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Quantity must be greater than 0',
     );
   });
 

--- a/gatsby-theme-shopify-core/src/hooks/index.ts
+++ b/gatsby-theme-shopify-core/src/hooks/index.ts
@@ -3,6 +3,8 @@ export {useCart} from './useCart';
 export {useCartCount} from './useCartCount';
 export {useAddItemToCart} from './useAddItemToCart';
 export {useAddItemsToCart} from './useAddItemsToCart';
+export {useRemoveItemFromCart} from './useRemoveItemFromCart';
+export {useRemoveItemsFromCart} from './useRemoveItemsFromCart';
 export {useCartItems} from './useCartItems';
 export {useCheckoutUrl} from './useCheckoutUrl';
 export {useGetLineItem} from './useGetLineItem';

--- a/gatsby-theme-shopify-core/src/hooks/useRemoveItemFromCart.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useRemoveItemFromCart.tsx
@@ -1,0 +1,14 @@
+import {useRemoveItemsFromCart} from './useRemoveItemsFromCart';
+
+export function useRemoveItemFromCart() {
+  const removeItemsFromCart = useRemoveItemsFromCart();
+
+  return function removeItemFromCart(variantId: number | string) {
+    if (variantId === '' || variantId == null) {
+      console.error(new Error('VariantId must not be blank or null'));
+      return false;
+    }
+
+    return removeItemsFromCart([String(variantId)]);
+  };
+}

--- a/gatsby-theme-shopify-core/src/hooks/useRemoveItemsFromCart.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useRemoveItemsFromCart.tsx
@@ -1,0 +1,43 @@
+import {useContext} from 'react';
+import {Context} from '../Context';
+import {useGetLineItem} from './useGetLineItem';
+
+export function useRemoveItemsFromCart() {
+  const {client, cart, setCart} = useContext(Context);
+  const getLineItem = useGetLineItem();
+
+  async function removeItemsFromCart(variantIds: string[]) {
+    try {
+      if (cart == null || client == null) {
+        throw new Error('Called removeItemsFromCart too soon');
+      }
+
+      if (variantIds.length < 1) {
+        throw new Error('Must include at least one item to remove');
+      }
+
+      const lineItemIds = variantIds.map((variantId) => {
+        const lineItem = getLineItem(variantId);
+        if (lineItem === null) {
+          throw new Error(
+            `Could not find line item in cart with variant id: ${variantId}`,
+          );
+        }
+        return String(lineItem.id);
+      });
+
+      const newCart = await client.checkout.removeLineItems(
+        cart.id,
+        lineItemIds,
+      );
+      setCart(newCart);
+
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }
+
+  return removeItemsFromCart;
+}

--- a/gatsby-theme-shopify-core/src/hooks/useUpdateItemQuantity.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useUpdateItemQuantity.tsx
@@ -16,13 +16,12 @@ export function useUpdateItemQuantity() {
       return false;
     }
 
-    if (Number(quantity) < 1) {
-      console.error('Quantity must be greater than 1');
+    if (quantity == null || Number(quantity) < 0) {
+      console.error('Quantity must be greater than 0');
       return false;
     }
 
     const lineItem = getLineItem(variantId);
-
     if (lineItem == null) {
       console.error(`Item with variantId ${variantId} not in cart`);
       return false;

--- a/gatsby-theme-shopify-core/src/mocks/client.ts
+++ b/gatsby-theme-shopify-core/src/mocks/client.ts
@@ -38,8 +38,19 @@ export const CLIENT = {
     }),
     clearLineItems: jest.fn(),
     addVariants: jest.fn(),
-    removeLineItems: jest.fn(),
-    updateLineItems: jest.fn((cartId, itemsToUpdate) => {
+    removeLineItems: jest.fn((_, lineItemIds) => {
+      const newLineItems = CART.lineItems
+        .map((lineItem) => {
+          if (lineItemIds.includes(lineItem.id)) {
+            return null;
+          }
+          return lineItem;
+        })
+        .filter(Boolean);
+
+      return {...CART, lineItems: newLineItems};
+    }),
+    updateLineItems: jest.fn((_, itemsToUpdate) => {
       const lineItems = CART.lineItems.map((lineItem) => {
         let newLineItem = lineItem;
         itemsToUpdate.forEach((item: {id: string; quantity: number}) => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:fix": "yarn lint --fix",
     "pretty": "prettier --write \"**/*.{ts,tsx,js,css,scss}\"",
     "type-check": "yarn workspace gatsby-theme-shopify-core tsc --noEmit",
-    "build-example": "yarn workspace example build"
+    "build-example": "yarn workspace example build",
+    "check-all": "yarn lint && yarn type-check && yarn test-build"
   },
   "workspaces": [
     "gatsby-theme-shopify-core",


### PR DESCRIPTION
This PR:
- adds `useRemoveItemFromCart`
- adds `useRemoveItemsFromCart`
- does some misc tidying up
- adds `check-all`, a yarn script to easily check lint, types, and tests