### PR TITLE
Add "escape" hooks

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "gatsby": "^2.19.18",
     "gatsby-image": "^2.2.41",
     "gatsby-plugin-sharp": "^2.4.5",
-    "gatsby-theme-shopify-core": "1.0.0",
+    "gatsby-theme-shopify-core": "0.1.0",
     "gatsby-transformer-sharp": "^2.3.16",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -2,9 +2,9 @@ import React, {useState} from 'react';
 import {graphql} from 'gatsby';
 import Image from 'gatsby-image';
 import {
-  useClient,
-  useCart,
+  useClientUnsafe,
   useCartCount,
+  useSetCartUnsafe,
   useAddItemToCart,
   useUpdateItemQuantity,
   useGetLineItem,
@@ -24,9 +24,9 @@ function IndexPage({data}) {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const client = useClient();
+  const client = useClientUnsafe();
   const checkoutUrl = useCheckoutUrl();
-  const {setCart} = useCart();
+  const setCart = useSetCartUnsafe();
   const cartCount = useCartCount();
   const addItemToCart = useAddItemToCart();
   const removeItemFromCart = useRemoveItemFromCart();

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useCart.test.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useCart.test.tsx
@@ -1,0 +1,15 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {Mocks, renderHookWithContext} from '../../mocks';
+import {useCart} from '../useCart';
+
+describe('useCart()', () => {
+  it('returns the cart object', async () => {
+    const {result} = await renderHookWithContext(() => useCart());
+    expect(result.current).toBe(Mocks.CART);
+  });
+
+  it('returns null if it is not wrapped in a provider', async () => {
+    const {result} = renderHook(() => useCart());
+    expect(result.current).toBeNull();
+  });
+});

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useClientUnsafe.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useClientUnsafe.tsx
@@ -1,0 +1,15 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {Mocks, renderHookWithContext} from '../../mocks';
+import {useClientUnsafe} from '../useClientUnsafe';
+
+describe('useClientUnsafe()', () => {
+  it('returns the client object', async () => {
+    const {result} = await renderHookWithContext(() => useClientUnsafe());
+    expect(result.current).toBe(Mocks.CLIENT);
+  });
+
+  it('returns null if it is not wrapped in a provider', async () => {
+    const {result} = renderHook(() => useClientUnsafe());
+    expect(result.current).toBeNull();
+  });
+});

--- a/gatsby-theme-shopify-core/src/hooks/__tests__/useSetCartUnsafe.test.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/__tests__/useSetCartUnsafe.test.tsx
@@ -1,0 +1,31 @@
+import {renderHook, act} from '@testing-library/react-hooks';
+import {Mocks, renderHookWithContext} from '../../mocks';
+import {LocalStorage, LocalStorageKeys} from '../../utils';
+import {useSetCartUnsafe} from '../useSetCartUnsafe';
+
+describe('useSetCartUnsafe()', () => {
+  it('returns a function to set the cart in state', async () => {
+    const localStorageSpy = jest.spyOn(LocalStorage, 'set');
+    const {result} = await renderHookWithContext(() => useSetCartUnsafe());
+
+    const newCart = {...Mocks.CART, id: 'my_new_cart'};
+    act(() => {
+      // @ts-ignore
+      result.current(newCart);
+    });
+
+    expect(localStorageSpy).toHaveBeenCalledWith(
+      LocalStorageKeys.CART,
+      JSON.stringify(newCart),
+    );
+  });
+
+  it('throws an error if a given variant Id is not found in the cart', async () => {
+    const {result} = renderHook(() => useSetCartUnsafe());
+
+    // @ts-ignore
+    expect(() => result.current(Mocks.CART)).toThrow(
+      'You forgot to wrap this in a Provider object',
+    );
+  });
+});

--- a/gatsby-theme-shopify-core/src/hooks/index.ts
+++ b/gatsby-theme-shopify-core/src/hooks/index.ts
@@ -1,4 +1,5 @@
-export {useClient} from './useClient';
+export {useClientUnsafe} from './useClientUnsafe';
+export {useSetCartUnsafe} from './useSetCartUnsafe';
 export {useCart} from './useCart';
 export {useCartCount} from './useCartCount';
 export {useAddItemToCart} from './useAddItemToCart';

--- a/gatsby-theme-shopify-core/src/hooks/useCart.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useCart.tsx
@@ -2,6 +2,6 @@ import {useContext} from 'react';
 import {Context} from '../Context';
 
 export function useCart() {
-  const {cart, setCart} = useContext(Context);
-  return {cart, setCart};
+  const {cart} = useContext(Context);
+  return cart;
 }

--- a/gatsby-theme-shopify-core/src/hooks/useCheckoutUrl.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useCheckoutUrl.tsx
@@ -1,7 +1,8 @@
-import {useCart} from './useCart';
+import {useContext} from 'react';
+import {Context} from '../Context';
 
 export function useCheckoutUrl(): string | null {
-  const {cart} = useCart();
+  const {cart} = useContext(Context);
   if (cart == null) {
     return null;
   }

--- a/gatsby-theme-shopify-core/src/hooks/useClientUnsafe.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useClientUnsafe.tsx
@@ -1,7 +1,7 @@
 import {useContext} from 'react';
 import {Context} from '../Context';
 
-export function useClient() {
+export function useClientUnsafe() {
   const {client} = useContext(Context);
   return client;
 }

--- a/gatsby-theme-shopify-core/src/hooks/useSetCartUnsafe.tsx
+++ b/gatsby-theme-shopify-core/src/hooks/useSetCartUnsafe.tsx
@@ -1,0 +1,7 @@
+import {useContext} from 'react';
+import {Context} from '../Context';
+
+export function useSetCartUnsafe() {
+  const {setCart} = useContext(Context);
+  return setCart;
+}


### PR DESCRIPTION
This PR adds "escape" hooks, which allow the user to perform functions not currently found in Shopify-core but still use the state. These hooks are:
- `useCart`
- `useSetCartUnsafe`
- `useClientUnsafe`
The last two are named with 'unsafe' to inform the user that using them is outside the normal scope of `gatsby-theme-shopify-core`.